### PR TITLE
Publish draft to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: deploy-draft
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  deploy-draft:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          set -e -x
+          sudo apt-get -y install xml2rfc
+          wget https://github.com/mmarkdown/mmark/releases/download/v2.2.31/mmark_2.2.31_linux_amd64.tgz
+          sha256sum --check --status <<SHA256SUM
+          39e4a7bf939498127939e731c5a5a1b4f953f6de460276b27a5de662f274ab76  mmark_2.2.31_linux_amd64.tgz
+          SHA256SUM
+          mkdir -p ~/.local/bin
+          tar -x -f mmark_2.2.31_linux_amd64.tgz -C ~/.local/bin
+      - name: Generate draft
+        run: |
+          make pages
+          tar -c -f github-pages _site
+      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/deploy-pages@main

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ TXT=$(DRAFT)-$(VERSION).txt
 all: $(HTML) $(TXT)
 
 pages: $(HTML) $(TXT)
-	cp -p $(TXT) docs/$(TXT)
-	cp -p $(HTML) docs/$(HTML)
+	mkdir _site
+	cp -p $(TXT) _site/$(TXT)
+	cp -p $(HTML) _site/$(HTML)
+	cp -p $(HTML) _site/index.html
 
 $(HTML): $(XML)
 	xml2rfc --html -o $@ $<


### PR DESCRIPTION
What it says on the tin. On update to the main branch, the GitHub Pages site for the draft repository is automatically updated with the newest version.